### PR TITLE
Improvements to reuse event parser and http modification interfaces

### DIFF
--- a/core/src/main/java/org/commonjava/rwx/estream/EventStreamParser.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/EventStreamParser.java
@@ -26,4 +26,6 @@ public interface EventStreamParser
 
     List<Event<?>> getEvents();
 
+    void clearEvents();
+
 }

--- a/core/src/main/java/org/commonjava/rwx/impl/estream/EventStreamParserImpl.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/estream/EventStreamParserImpl.java
@@ -43,6 +43,12 @@ public class EventStreamParserImpl
     }
 
     @Override
+    public void clearEvents()
+    {
+        events.clear();
+    }
+
+    @Override
     public EventStreamParserImpl arrayElement( final int index, final Object value, final ValueType type )
     {
         events.add( new ArrayEvent( index, value, type ) );

--- a/http/src/main/java/org/commonjava/rwx/http/RequestModifier.java
+++ b/http/src/main/java/org/commonjava/rwx/http/RequestModifier.java
@@ -1,0 +1,12 @@
+package org.commonjava.rwx.http;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+
+/**
+ * Created by jdcasey on 12/3/15.
+ */
+public interface RequestModifier
+{
+    void modifyRequest( HttpPost request );
+}

--- a/http/src/main/java/org/commonjava/rwx/http/SyncEStreamClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/SyncEStreamClient.java
@@ -30,6 +30,12 @@ public interface SyncEStreamClient
     List<Event<?>> call( List<Event<?>> requestEvents, boolean expectVoidResponse )
         throws XmlRpcException;
 
+    List<Event<?>> call( List<Event<?>> requestEvents, boolean expectVoidResponse, UrlBuilder urlBuilder, RequestModifier requestModifier )
+            throws XmlRpcException;
+
     List<Event<?>> call( EventStreamGenerator requestGenerator, boolean expectVoidResponse )
         throws XmlRpcException;
+
+    List<Event<?>> call( EventStreamGenerator requestGenerator, boolean expectVoidResponse, UrlBuilder urlBuilder, RequestModifier requestModifier )
+            throws XmlRpcException;
 }

--- a/http/src/main/java/org/commonjava/rwx/http/SyncObjectClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/SyncObjectClient.java
@@ -28,4 +28,7 @@ public interface SyncObjectClient
     <T> T call( Object request, Class<T> responseType )
             throws XmlRpcException;
 
+    <T> T call( Object request, Class<T> responseType, UrlBuilder urlBuilder, RequestModifier requestModifier )
+            throws XmlRpcException;
+
 }

--- a/http/src/main/java/org/commonjava/rwx/http/UrlBuilder.java
+++ b/http/src/main/java/org/commonjava/rwx/http/UrlBuilder.java
@@ -1,0 +1,11 @@
+package org.commonjava.rwx.http;
+
+import java.net.MalformedURLException;
+
+/**
+ * Created by jdcasey on 12/3/15.
+ */
+public interface UrlBuilder
+{
+    String buildUrl( String baseUrl ) throws MalformedURLException;
+}


### PR DESCRIPTION
- interfaces allow modification of http requests (per-call), which are lambda targets
