### PR TITLE
license headers, change to APLv2, minor bugfixes and improved annotations

### DIFF
--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0"?>
 <!--
-  Copyright (c) 2010 Red Hat, Inc.
-  
-  This program is licensed to you under Version 3 only of the GNU
-  General Public License as published by the Free Software 
-  Foundation. This program is distributed in the hope that it will be 
-  useful, but WITHOUT ANY WARRANTY; without even the implied 
-  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
-  PURPOSE.
-  
-  See the GNU General Public License Version 3 for more details.
-  You should have received a copy of the GNU General Public License 
-  Version 3 along with this program. 
-  
-  If not, see http://www.gnu.org/licenses/.
+
+    Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/bindings/src/main/java/org/commonjava/rwx/binding/SimpleNoParamsRequest.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/SimpleNoParamsRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/SimpleNoParamsRequest.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/SimpleNoParamsRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding;
 
 import org.commonjava.rwx.error.XmlRpcException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/VoidResponse.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/VoidResponse.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding;
 
 import org.commonjava.rwx.binding.anno.Response;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/VoidResponse.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/VoidResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/AnnotationUtils.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/AnnotationUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/AnnotationUtils.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/AnnotationUtils.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import org.commonjava.rwx.binding.SimpleNoParamsRequest;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/ArrayPart.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/ArrayPart.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/ArrayPart.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/ArrayPart.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Contains.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Contains.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Contains.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Contains.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Converter.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Converter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Converter.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Converter.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target( ElementType.FIELD )
+@Target( {ElementType.FIELD, ElementType.TYPE} )
 @Retention( RetentionPolicy.RUNTIME )
 public @interface Converter
 {

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Converter.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Converter.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import org.commonjava.rwx.binding.spi.value.ValueBinder;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/DataIndex.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/DataIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/DataIndex.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/DataIndex.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/DataKey.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/DataKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/DataKey.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/DataKey.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Ignored.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Ignored.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Ignored.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Ignored.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/ImportMappings.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/ImportMappings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/ImportMappings.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/ImportMappings.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/IndexRefs.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/IndexRefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/IndexRefs.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/IndexRefs.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/KeyRefs.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/KeyRefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/KeyRefs.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/KeyRefs.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Request.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Request.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Request.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Request.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Response.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Response.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/Response.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/Response.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/SkipNull.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/SkipNull.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/SkipNull.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/SkipNull.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/SkipNull.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/SkipNull.java
@@ -1,0 +1,15 @@
+package org.commonjava.rwx.binding.anno;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by jdcasey on 1/14/16.
+ */
+@Target( {ElementType.FIELD, ElementType.METHOD, ElementType.TYPE} )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface SkipNull
+{
+}

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/StructPart.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/StructPart.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/anno/StructPart.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/anno/StructPart.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.anno;
 
 import java.lang.annotation.ElementType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/convert/AbstractEnumConverter.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/convert/AbstractEnumConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/convert/AbstractEnumConverter.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/convert/AbstractEnumConverter.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.convert;
 
 import org.commonjava.rwx.binding.mapping.Mapping;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/convert/FlexibleDateConverter.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/convert/FlexibleDateConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/convert/FlexibleDateConverter.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/convert/FlexibleDateConverter.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.convert;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/error/BindException.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/error/BindException.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.error;
 
 import org.commonjava.rwx.error.XmlRpcException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/error/BindException.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/error/BindException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapper.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapper.java
@@ -38,6 +38,8 @@ import org.commonjava.rwx.binding.mapping.FieldBinding;
 import org.commonjava.rwx.binding.mapping.Mapping;
 import org.commonjava.rwx.binding.mapping.StructMapping;
 import org.commonjava.rwx.binding.spi.Mapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
@@ -205,9 +207,16 @@ public class ReflectionMapper
 
         final FieldBinding binding = new FieldBinding( name, type );
 
-        final Converter bindVia = field.getAnnotation( Converter.class );
+        Converter bindVia = field.getAnnotation( Converter.class );
+        if ( bindVia == null )
+        {
+            bindVia = type.getAnnotation( Converter.class );
+        }
+
         if ( bindVia != null )
         {
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.trace( "Adding ValueBinder: {} for: {} in: {}", bindVia.value().getName(), field, field.getDeclaringClass().getName() );
             binding.withValueBinderType( bindVia.value() );
         }
 
@@ -228,6 +237,9 @@ public class ReflectionMapper
                                     final String[] ctorKeys, final Map<Class<?>, Mapping<?>> mappings )
             throws BindException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Creating binding for field: {}", field );
+
         if ( Modifier.isTransient( field.getModifiers() ) )
         {
             throw new BindException(
@@ -259,9 +271,15 @@ public class ReflectionMapper
 
         final FieldBinding binding = new FieldBinding( name, type );
 
-        final Converter bindVia = field.getAnnotation( Converter.class );
+        Converter bindVia = field.getAnnotation( Converter.class );
+        if ( bindVia == null )
+        {
+            bindVia = type.getAnnotation( Converter.class );
+        }
+
         if ( bindVia != null )
         {
+            logger.trace( "Adding ValueBinder: {} for: {} in: {}", bindVia.value().getName(), field, field.getDeclaringClass().getName() );
             binding.withValueBinderType( bindVia.value() );
         }
 

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapper.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapper.java
@@ -53,14 +53,14 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 public class ReflectionMapper
-    implements Mapper
+        implements Mapper
 {
 
     private static final Map<String, WeakReference<Map<Class<?>, Mapping<?>>>> ROOT_CACHE =
-        new HashMap<String, WeakReference<Map<Class<?>, Mapping<?>>>>();
+            new HashMap<String, WeakReference<Map<Class<?>, Mapping<?>>>>();
 
     public synchronized Map<Class<?>, Mapping<?>> loadRecipes( final Class<?>... roots )
-        throws BindException
+            throws BindException
     {
         final Map<Class<?>, Mapping<?>> mappings = new HashMap<Class<?>, Mapping<?>>();
 
@@ -76,7 +76,7 @@ public class ReflectionMapper
     }
 
     private void processRoot( final Class<?> root, final Map<Class<?>, Mapping<?>> mappings )
-        throws BindException
+            throws BindException
     {
         Map<Class<?>, Mapping<?>> current;
 
@@ -97,7 +97,7 @@ public class ReflectionMapper
             else
             {
                 throw new BindException(
-                                         "Invalid message root. Class must be annotated with either @Request or @Response." );
+                        "Invalid message root: " + root.getName() + " Class must be annotated with either @Request or @Response." );
             }
 
             ROOT_CACHE.put( rootType, new WeakReference<Map<Class<?>, Mapping<?>>>( current ) );
@@ -107,7 +107,7 @@ public class ReflectionMapper
     }
 
     protected ArrayMapping processArrayPart( final Class<?> type, final Map<Class<?>, Mapping<?>> mappings )
-        throws BindException
+            throws BindException
     {
         final String typeName = type.getName();
         int[] ctorIndices = new int[0];
@@ -136,13 +136,13 @@ public class ReflectionMapper
                 {
                     if ( taken.contains( di.value() ) )
                     {
-                        throw new BindException( "More than one field declares data-index: " + di.value() + " in: "
-                            + typeName );
+                        throw new BindException(
+                                "More than one field declares data-index: " + di.value() + ". Type: " + typeName );
                     }
 
                     if ( Modifier.isTransient( field.getModifiers() ) )
                     {
-                        throw new BindException( "Fields annotated with @DataIndex cannot be marked as transient!" );
+                        throw new BindException( "Fields annotated with @DataIndex cannot be marked as transient! Type: " + typeName );
                     }
                     else
                     {
@@ -180,7 +180,7 @@ public class ReflectionMapper
 
     protected void addFieldBinding( final ArrayMapping recipe, final int index, final Field field,
                                     final int[] ctorIndices, final Map<Class<?>, Mapping<?>> mappings )
-        throws BindException
+            throws BindException
     {
         if ( Modifier.isFinal( field.getModifiers() ) )
         {
@@ -197,7 +197,8 @@ public class ReflectionMapper
             if ( !found )
             {
                 throw new BindException(
-                                         "Fields annotated with @DataIndex cannot be marked as final unless they're included in the @IndexRefs constructor annotation!" );
+                        "Fields annotated with @DataIndex cannot be marked as final unless they're included in the @IndexRefs constructor annotation! Type: "
+                                + recipe.getObjectType().getName() );
             }
         }
 
@@ -227,11 +228,13 @@ public class ReflectionMapper
 
     protected void addFieldBinding( final StructMapping recipe, final String key, final Field field,
                                     final String[] ctorKeys, final Map<Class<?>, Mapping<?>> mappings )
-        throws BindException
+            throws BindException
     {
         if ( Modifier.isTransient( field.getModifiers() ) )
         {
-            throw new BindException( "Fields annotated with @DataKey cannot be marked as transient!" );
+            throw new BindException(
+                    "Fields annotated with @DataKey cannot be marked as transient! Type: " + recipe.getObjectType()
+                                                                                                   .getName() );
         }
         else if ( Modifier.isFinal( field.getModifiers() ) )
         {
@@ -248,7 +251,8 @@ public class ReflectionMapper
             if ( !found )
             {
                 throw new BindException(
-                                         "Fields annotated with @DataKey cannot be marked as final unless they're included in the @KeyRefs constructor annotation!" );
+                        "Fields annotated with @DataKey cannot be marked as final unless they're included in the @KeyRefs constructor annotation! Type: "
+                                + recipe.getObjectType().getName() );
             }
         }
 
@@ -278,7 +282,7 @@ public class ReflectionMapper
 
     @SuppressWarnings( "unchecked" )
     protected void processSupplementalMappings( final Class<?> type, final Map<Class<?>, Mapping<?>> mappings )
-        throws BindException
+            throws BindException
     {
         final ImportMappings extraMappings = type.getAnnotation( ImportMappings.class );
         if ( extraMappings != null )
@@ -298,7 +302,7 @@ public class ReflectionMapper
                     }
                     else
                     {
-                        throw new BindException( "Imported class is not a valid message-part: " + cls.getName() );
+                        throw new BindException( "Imported class is not a valid message-part: " + cls.getName() + ". Declared in: " + type.getName() );
                     }
                 }
             }
@@ -306,7 +310,7 @@ public class ReflectionMapper
     }
 
     protected Mapping<?> processBindingTarget( final Class<?> type, final Map<Class<?>, Mapping<?>> mappings )
-        throws BindException
+            throws BindException
     {
         if ( type.getAnnotation( ArrayPart.class ) != null )
         {
@@ -321,7 +325,7 @@ public class ReflectionMapper
     }
 
     protected StructMapping processStructPart( final Class<?> type, final Map<Class<?>, Mapping<?>> mappings )
-        throws BindException
+            throws BindException
     {
         final String typeName = type.getName();
         String[] ctorKeys = new String[0];
@@ -350,8 +354,8 @@ public class ReflectionMapper
                 {
                     if ( takenKeys.contains( dk.value() ) )
                     {
-                        throw new BindException( "More than one field declares data-key: " + dk.value() + " in: "
-                            + typeName );
+                        throw new BindException(
+                                "More than one field declares data-key: " + dk.value() + ". Type: " + typeName );
                     }
 
                     addFieldBinding( mapping, dk.value(), field, ctorKeys, mappings );
@@ -375,7 +379,7 @@ public class ReflectionMapper
             final String name = field.getName();
             if ( takenKeys.contains( name ) )
             {
-                throw new BindException( "More than one field declares data-key: " + name + " in: " + typeName );
+                throw new BindException( "More than one field declares data-key: " + name + ". Type: " + typeName );
             }
 
             if ( !Modifier.isTransient( field.getModifiers() ) )

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapper.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapper.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.reflect;
 
 import static org.commonjava.rwx.binding.anno.AnnotationUtils.hasAnnotation;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapper.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
@@ -37,6 +37,7 @@ import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.error.XmlRpcFaultException;
 import org.commonjava.rwx.spi.XmlRpcGenerator;
 import org.commonjava.rwx.spi.XmlRpcListener;
+import org.commonjava.rwx.util.ValueCoercion;
 import org.commonjava.rwx.vocab.ValueType;
 
 import java.lang.reflect.Field;
@@ -332,7 +333,12 @@ public class ReflectionUnbinder
                 }
                 else
                 {
-                    value = type.coercion().toString( value );
+                    ValueCoercion coercion = type.coercion();
+                    if ( coercion == null )
+                    {
+                        throw new XmlRpcException( "Cannot render {} (type: {}) to string. It has no corresponding coercion, and isn't an @ArrayPart or a @StructPart!" );
+                    }
+                    value = coercion.toString( value );
                 }
 
                 listener.value( value, type );

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
@@ -24,6 +24,7 @@ import static org.commonjava.rwx.binding.anno.AnnotationUtils.isResponse;
 import org.commonjava.rwx.binding.anno.ArrayPart;
 import org.commonjava.rwx.binding.anno.Converter;
 import org.commonjava.rwx.binding.anno.Contains;
+import org.commonjava.rwx.binding.anno.SkipNull;
 import org.commonjava.rwx.binding.anno.StructPart;
 import org.commonjava.rwx.binding.error.BindException;
 import org.commonjava.rwx.binding.internal.xbr.XBRBinderInstantiator;
@@ -35,10 +36,14 @@ import org.commonjava.rwx.binding.spi.value.ValueBinder;
 import org.commonjava.rwx.error.CoercionException;
 import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.error.XmlRpcFaultException;
+import org.commonjava.rwx.impl.stax.helper.ValueHelper;
 import org.commonjava.rwx.spi.XmlRpcGenerator;
 import org.commonjava.rwx.spi.XmlRpcListener;
+import org.commonjava.rwx.util.LambdaHolder;
 import org.commonjava.rwx.util.ValueCoercion;
 import org.commonjava.rwx.vocab.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -51,7 +56,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class ReflectionUnbinder
-    implements XmlRpcGenerator
+        implements XmlRpcGenerator
 {
 
     private final Map<Class<?>, ValueType> typeCache = new HashMap<Class<?>, ValueType>();
@@ -61,7 +66,7 @@ public class ReflectionUnbinder
     private final Object message;
 
     public ReflectionUnbinder( final Object message, final Map<Class<?>, Mapping<?>> recipes )
-        throws BindException
+            throws BindException
     {
         this.message = message;
         recipesByClass = recipes;
@@ -70,7 +75,7 @@ public class ReflectionUnbinder
     @SuppressWarnings( "unchecked" )
     @Override
     public ReflectionUnbinder generate( final XmlRpcListener listener )
-        throws XmlRpcException
+            throws XmlRpcException
     {
         if ( message instanceof XmlRpcFaultException )
         {
@@ -121,7 +126,7 @@ public class ReflectionUnbinder
 
     @SuppressWarnings( "unchecked" )
     private void fireMessageEvents( final XmlRpcListener listener )
-        throws XmlRpcException
+            throws XmlRpcException
     {
         final Class<?> messageCls = message.getClass();
         final Mapping<Integer> recipe = (Mapping<Integer>) recipesByClass.get( messageCls );
@@ -133,20 +138,53 @@ public class ReflectionUnbinder
 
         final Map<Integer, FieldBinding> bindings = new TreeMap<Integer, FieldBinding>( recipe.getFieldBindings() );
 
-        for ( final Map.Entry<Integer, FieldBinding> entry : bindings.entrySet() )
-        {
-            listener.startParameter( entry.getKey() );
-            final Object value = fireValueEvents( entry.getValue(), message, listener );
+        LambdaHolder<XmlRpcException> holder = new LambdaHolder<>();
+        bindings.forEach( ( index, fieldBinding ) -> {
+            try
+            {
+                fireValueEvents( fieldBinding, message, listener, ( val, t ) -> {
+                    try
+                    {
+                        listener.startParameter( index );
+                        return true;
+                    }
+                    catch ( XmlRpcException e )
+                    {
+                        holder.set( e );
+                    }
+                    return false;
+                }, ( val, t ) -> {
+                    try
+                    {
+                        listener.parameter( index, val, t );
+                        listener.endParameter();
+                        return true;
+                    }
+                    catch ( XmlRpcException e )
+                    {
+                        holder.set( e );
+                    }
+                    return false;
+                } );
+            }
+            catch ( XmlRpcException e )
+            {
+                holder.set( e );
+            }
+        } );
 
-            listener.parameter( entry.getKey(), value, typeOf( value, entry.getValue() ) );
-            listener.endParameter();
+        if ( holder.has() )
+        {
+            throw holder.get();
         }
     }
 
     @SuppressWarnings( "unchecked" )
     private List<Object> fireArrayEvents( final Class<?> type, final Object part, final XmlRpcListener listener )
-        throws XmlRpcException
+            throws XmlRpcException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Getting mapping recipe for: {}", type.getSimpleName() );
         final Mapping<Integer> recipe = (Mapping<Integer>) recipesByClass.get( type );
 
         if ( recipe == null )
@@ -159,21 +197,52 @@ public class ReflectionUnbinder
         listener.startArray();
 
         final List<Object> result = new ArrayList<Object>();
-        for ( final Map.Entry<Integer, FieldBinding> entry : bindings.entrySet() )
-        {
-            listener.startArrayElement( entry.getKey() );
 
-            final Object value = fireValueEvents( entry.getValue(), part, listener );
-
-            while ( result.size() < entry.getKey() )
+        LambdaHolder<XmlRpcException> holder = new LambdaHolder<>();
+        bindings.forEach( ( index, fieldBinding ) -> {
+            try
             {
-                result.add( null );
+                Object arrayEntry = fireValueEvents( fieldBinding, part, listener, ( val, t ) -> {
+                    try
+                    {
+                        listener.startArrayElement( index );
+                        return true;
+                    }
+                    catch ( XmlRpcException e )
+                    {
+                        holder.set( e );
+                    }
+                    return false;
+                }, ( val, t ) -> {
+                    try
+                    {
+                        while ( result.size() < index )
+                        {
+                            result.add( null );
+                        }
+
+                        result.add( val );
+
+                        listener.arrayElement( index, val, t );
+                        listener.endArrayElement();
+                        return true;
+                    }
+                    catch ( XmlRpcException e )
+                    {
+                        holder.set( e );
+                    }
+                    return false;
+                } );
             }
+            catch ( XmlRpcException e )
+            {
+                holder.set( e );
+            }
+        } );
 
-            result.add( value );
-
-            listener.arrayElement( entry.getKey(), value, typeOf( value, entry.getValue() ) );
-            listener.endArrayElement();
+        if ( holder.has() )
+        {
+            throw holder.get();
         }
 
         listener.endArray();
@@ -182,8 +251,9 @@ public class ReflectionUnbinder
     }
 
     @SuppressWarnings( "unchecked" )
-    private Map<String, Object> fireStructEvents( final Class<?> type, final Object part, final XmlRpcListener listener )
-        throws XmlRpcException
+    private Map<String, Object> fireStructEvents( final Class<?> type, final Object part,
+                                                  final XmlRpcListener listener )
+            throws XmlRpcException
     {
         final Mapping<String> recipe = (Mapping<String>) recipesByClass.get( type );
 
@@ -194,17 +264,49 @@ public class ReflectionUnbinder
 
         listener.startStruct();
 
+        LambdaHolder<XmlRpcException> holder = new LambdaHolder<>();
+        Map<String, FieldBinding> bindings = recipe.getFieldBindings();
+
         final Map<String, Object> result = new LinkedHashMap<String, Object>();
-        for ( final Map.Entry<String, FieldBinding> entry : recipe.getFieldBindings().entrySet() )
+        bindings.forEach( ( memberName, fieldBinding ) -> {
+            try
+            {
+                Object arrayEntry = fireValueEvents( fieldBinding, part, listener, ( val, t ) -> {
+                    try
+                    {
+                        listener.startStructMember( memberName );
+                        return true;
+                    }
+                    catch ( XmlRpcException e )
+                    {
+                        holder.set( e );
+                    }
+                    return false;
+                }, ( val, t ) -> {
+                    try
+                    {
+                        result.put( memberName, val );
+
+                        listener.structMember( memberName, val, t );
+                        listener.endStructMember();
+                        return true;
+                    }
+                    catch ( XmlRpcException e )
+                    {
+                        holder.set( e );
+                    }
+                    return false;
+                } );
+            }
+            catch ( XmlRpcException e )
+            {
+                holder.set( e );
+            }
+        } );
+
+        if ( holder.has() )
         {
-            listener.startStructMember( entry.getKey() );
-
-            final Object value = fireValueEvents( entry.getValue(), part, listener );
-
-            result.put( entry.getKey(), value );
-
-            listener.structMember( entry.getKey(), value, typeOf( value, entry.getValue() ) );
-            listener.endStructMember();
+            throw holder.get();
         }
 
         listener.endStruct();
@@ -239,7 +341,7 @@ public class ReflectionUnbinder
     }
 
     private ValueType typeOf( final Object value, final FieldBinding binding )
-        throws BindException
+            throws BindException
     {
         if ( value == null )
         {
@@ -265,7 +367,7 @@ public class ReflectionUnbinder
                 else
                 {
                     throw new BindException( "Unknown recipe reference type: " + binding.getFieldType() + "\nField: "
-                        + binding.getFieldName() + "\nClass: " + cls.getName() );
+                                                     + binding.getFieldName() + "\nClass: " + cls.getName() );
                 }
             }
             else
@@ -282,8 +384,14 @@ public class ReflectionUnbinder
         return type;
     }
 
-    private Object fireValueEvents( final FieldBinding binding, final Object parent, final XmlRpcListener listener )
-        throws XmlRpcException
+    public interface EventCallback
+    {
+        boolean call( Object val, ValueType type );
+    }
+
+    private Object fireValueEvents( final FieldBinding binding, final Object parent, final XmlRpcListener listener,
+                                    EventCallback before, EventCallback after )
+            throws XmlRpcException
     {
         final Class<?> parentCls = parent.getClass();
         try
@@ -293,9 +401,29 @@ public class ReflectionUnbinder
             field.setAccessible( true );
 
             Object value = field.get( parent );
+
+            if ( isSuppressedNull( field, parentCls, value ) )
+            {
+                return null;
+            }
+
             final ValueType type = typeOf( value, binding );
 
-            final Converter converter = field.getAnnotation( Converter.class );
+            if ( before != null )
+            {
+                if ( !before.call( value, type ) )
+                {
+                    return null;
+                }
+            }
+
+            Converter converter = field.getAnnotation( Converter.class );
+            if ( converter == null )
+            {
+                Class<?> fieldType = field.getType();
+                converter = fieldType.getAnnotation( Converter.class );
+            }
+
             if ( converter != null )
             {
                 final ValueBinder vc = XBRBinderInstantiator.newValueUnbinder( converter );
@@ -314,7 +442,7 @@ public class ReflectionUnbinder
                 else
                 {
                     throw new BindException( "Unknown recipe reference type: " + binding.getFieldType() + "\nField: "
-                        + binding.getFieldName() + "\nClass: " + parentCls.getName() );
+                                                     + binding.getFieldName() + "\nClass: " + parentCls.getName() );
                 }
 
                 listener.value( value, type );
@@ -326,8 +454,8 @@ public class ReflectionUnbinder
                 {
                     fireMapEvents( value, binding.getFieldName(), contains, listener );
                 }
-                else if ( binding.getFieldType().isArray()
-                    || Collection.class.isAssignableFrom( binding.getFieldType() ) )
+                else if ( binding.getFieldType().isArray() || Collection.class.isAssignableFrom(
+                        binding.getFieldType() ) )
                 {
                     fireCollectionEvents( value, binding.getFieldName(), contains, listener );
                 }
@@ -336,7 +464,8 @@ public class ReflectionUnbinder
                     ValueCoercion coercion = type.coercion();
                     if ( coercion == null )
                     {
-                        throw new XmlRpcException( "Cannot render {} (type: {}) to string. It has no corresponding coercion, and isn't an @ArrayPart or a @StructPart!" );
+                        throw new XmlRpcException(
+                                "Cannot render {} (type: {}) to string. It has no corresponding coercion, and isn't an @ArrayPart or a @StructPart!" );
                     }
                     value = coercion.toString( value );
                 }
@@ -344,17 +473,39 @@ public class ReflectionUnbinder
                 listener.value( value, type );
             }
 
+            if ( after != null )
+            {
+                if ( !after.call( value, type ) )
+                {
+                    return null;
+                }
+            }
+
             return value;
         }
         catch ( final IllegalAccessException e )
         {
-            throw new BindException( "Cannot retrieve field: " + binding.getFieldName() + " in class: "
-                + parentCls.getName() + "\nError: " + e.getMessage(), e );
+            throw new BindException(
+                    "Cannot retrieve field: " + binding.getFieldName() + " in class: " + parentCls.getName()
+                            + "\nError: " + e.getMessage(), e );
         }
     }
 
+    private boolean isSuppressedNull( Field field, Class<?> cls, Object value )
+    {
+        if ( value == null )
+        {
+            if ( field.getAnnotation( SkipNull.class ) != null || cls.getAnnotation( SkipNull.class ) != null )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private Field findField( final FieldBinding binding, final Class<?> parentCls )
-        throws BindException
+            throws BindException
     {
         Field field = null;
         Class<?> fieldOwner = parentCls;
@@ -374,8 +525,9 @@ public class ReflectionUnbinder
 
         if ( field == null )
         {
-            throw new BindException( "Cannot find field: " + binding.getFieldName()
-                + " in class (or parent classes of): " + parentCls.getName() );
+            throw new BindException(
+                    "Cannot find field: " + binding.getFieldName() + " in class (or parent classes of): "
+                            + parentCls.getName() );
         }
 
         return field;
@@ -384,7 +536,7 @@ public class ReflectionUnbinder
     @SuppressWarnings( "unchecked" )
     private void fireMapEvents( final Object values, final String fieldName, final Contains contains,
                                 final XmlRpcListener listener )
-        throws XmlRpcException
+            throws XmlRpcException
     {
         ValueType vt = typeOf( contains );
 
@@ -430,7 +582,7 @@ public class ReflectionUnbinder
     @SuppressWarnings( "unchecked" )
     private void fireCollectionEvents( final Object values, final String fieldName, final Contains contains,
                                        final XmlRpcListener listener )
-        throws XmlRpcException
+            throws XmlRpcException
     {
         ValueType vt = typeOf( contains );
 
@@ -459,7 +611,9 @@ public class ReflectionUnbinder
 
             if ( vt == null )
             {
-                throw new CoercionException( "Cannot find suitable coercion for type: " + (contains == null ? "Un-annotated collection" : contains.value()) );
+                throw new CoercionException( "Cannot find suitable coercion for type: " + ( contains == null ?
+                        "Un-annotated collection" :
+                        contains.value() ) );
             }
 
             listener.startArrayElement( i );

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.reflect;
 
 import static org.commonjava.rwx.binding.anno.AnnotationUtils.getRequestMethod;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinder.java
@@ -34,6 +34,7 @@ import org.commonjava.rwx.binding.mapping.FieldBinding;
 import org.commonjava.rwx.binding.mapping.Mapping;
 import org.commonjava.rwx.binding.mapping.StructMapping;
 import org.commonjava.rwx.binding.spi.value.ValueBinder;
+import org.commonjava.rwx.error.CoercionException;
 import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.error.XmlRpcFaultException;
 import org.commonjava.rwx.spi.XmlRpcGenerator;
@@ -151,7 +152,7 @@ public class ReflectionUnbinder
 
         if ( recipe == null )
         {
-            throw new BindException( "Cannot find recipe for array value: " + type );
+            throw new BindException( "Cannot find recipe for array value: " + type.getName() );
         }
 
         final Map<Integer, FieldBinding> bindings = new TreeMap<Integer, FieldBinding>( recipe.getFieldBindings() );
@@ -189,7 +190,7 @@ public class ReflectionUnbinder
 
         if ( recipe == null )
         {
-            throw new BindException( "Cannot find recipe for array value: " + type );
+            throw new BindException( "Cannot find recipe for array value: " + type.getName() );
         }
 
         listener.startStruct();
@@ -265,7 +266,7 @@ public class ReflectionUnbinder
                 else
                 {
                     throw new BindException( "Unknown recipe reference type: " + binding.getFieldType() + "\nField: "
-                        + binding.getFieldName() );
+                        + binding.getFieldName() + "\nClass: " + cls.getName() );
                 }
             }
             else
@@ -450,6 +451,11 @@ public class ReflectionUnbinder
             {
                 final FieldBinding binding = new FieldBinding( fieldName + "<Map-Value>", type );
                 vt = typeOf( entry, binding );
+            }
+
+            if ( vt == null )
+            {
+                throw new CoercionException( "Cannot find suitable coercion for type: " + (contains == null ? "Un-annotated collection" : contains.value()) );
             }
 
             listener.startArrayElement( i );

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbindery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbindery.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.reflect;
 
 import org.commonjava.rwx.binding.mapping.Mapping;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRBinderInstantiator.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRBinderInstantiator.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr;
 
 import org.apache.xbean.recipe.ConstructionException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRBinderInstantiator.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRBinderInstantiator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRBindingContext.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRBindingContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRBindingContext.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRBindingContext.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr;
 
 import static org.commonjava.rwx.binding.anno.AnnotationUtils.hasAnnotation;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRCompositionBindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRCompositionBindery.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRCompositionBindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBRCompositionBindery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBeanRenderingBindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBeanRenderingBindery.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBeanRenderingBindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/XBeanRenderingBindery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import org.commonjava.rwx.binding.spi.Binder;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractBinder.java
@@ -21,6 +21,8 @@ import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.spi.AbstractXmlRpcListener;
 import org.commonjava.rwx.spi.XmlRpcListener;
 import org.commonjava.rwx.vocab.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractBinder
     extends AbstractXmlRpcListener
@@ -162,6 +164,8 @@ public abstract class AbstractBinder
     public final XmlRpcListener startStructMember( final String key )
         throws XmlRpcException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Start struct member: {}", key );
         return increment( startStructMemberInternal( key ) );
     }
 
@@ -188,6 +192,8 @@ public abstract class AbstractBinder
     public final XmlRpcListener value( final Object v, final ValueType t )
         throws XmlRpcException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Got {} value: {}", t, v );
         if ( count < 1 )
         {
             parent.value( value, valueType );
@@ -195,6 +201,7 @@ public abstract class AbstractBinder
         }
         else
         {
+            logger.trace( "Handing off to internal value call." );
             return valueInternal( v, t );
         }
     }

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractBinder.java
@@ -177,6 +177,8 @@ public abstract class AbstractBinder
 
     private final Binder decrement( final Binder binder )
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Decrementing count: {} to {} with binder: {}", count, (count-1), binder );
         count--;
 
         return binder;
@@ -184,12 +186,14 @@ public abstract class AbstractBinder
 
     private final Binder increment( final Binder binder )
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Incrementing count: {} to {} with binder: {}\nFrom: {}", count, (count+1), binder, Thread.currentThread().getStackTrace()[2] );
         count++;
         return binder;
     }
 
     @Override
-    public final XmlRpcListener value( final Object v, final ValueType t )
+    public XmlRpcListener value( final Object v, final ValueType t )
         throws XmlRpcException
     {
         Logger logger = LoggerFactory.getLogger( getClass() );

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractMappingBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractMappingBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import org.commonjava.rwx.binding.internal.xbr.XBRBindingContext;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractMappingBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/AbstractMappingBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import org.apache.xbean.recipe.ArrayRecipe;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayMappingBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayMappingBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayMappingBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayMappingBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import org.apache.xbean.recipe.ObjectRecipe;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayWrapperBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayWrapperBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import static org.commonjava.rwx.binding.anno.AnnotationUtils.hasAnnotation;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayWrapperBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/ArrayWrapperBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/CollectionBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/CollectionBinder.java
@@ -47,7 +47,16 @@ public class CollectionBinder
                              final XBRBindingContext context )
     {
         super( parent, getContainsType( field ), context );
-        bindVia = field == null ? null : field.getAnnotation( Converter.class );
+        Converter bv = null;
+        if ( field != null )
+        {
+            bv = field.getAnnotation( Converter.class );
+            if ( bv == null )
+            {
+                bv = field.getType().getAnnotation( Converter.class );
+            }
+        }
+        this.bindVia = bv;
         this.collectionType = collectionType;
     }
 
@@ -55,7 +64,16 @@ public class CollectionBinder
                              final Field field, final XBRBindingContext context )
     {
         super( parent, valueType, context );
-        bindVia = field == null ? null : field.getAnnotation( Converter.class );
+        Converter bv = null;
+        if ( field != null )
+        {
+            bv = field.getAnnotation( Converter.class );
+            if ( bv == null )
+            {
+                bv = field.getType().getAnnotation( Converter.class );
+            }
+        }
+        this.bindVia = bv;
         this.collectionType = collectionType;
     }
 

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/CollectionBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/CollectionBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/CollectionBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/CollectionBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import static org.commonjava.rwx.binding.anno.AnnotationUtils.getContainsType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MapBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MapBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MapBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MapBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import static org.commonjava.rwx.binding.anno.AnnotationUtils.getContainsType;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MapBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MapBinder.java
@@ -47,7 +47,16 @@ public class MapBinder
     {
         super( parent, getContainsType( field ), context );
         recipe = new MapRecipe( mapType );
-        bindVia = field == null ? null : field.getAnnotation( Converter.class );
+        Converter bv = null;
+        if ( field != null )
+        {
+            bv = field.getAnnotation( Converter.class );
+            if ( bv == null )
+            {
+                bv = field.getType().getAnnotation( Converter.class );
+            }
+        }
+        this.bindVia = bv;
     }
 
     @Override

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MessageBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MessageBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MessageBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MessageBinder.java
@@ -24,6 +24,8 @@ import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.error.XmlRpcFaultException;
 import org.commonjava.rwx.spi.XmlRpcListener;
 import org.commonjava.rwx.vocab.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 
@@ -66,9 +68,13 @@ public class MessageBinder
     protected Binder startParameterInternal( final int index )
         throws XmlRpcException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Start parameter: {}", index );
+
         final FieldBinding binding = getMapping().getFieldBinding( index );
         if ( binding == null )
         {
+            logger.trace( "No field binding for: {}", index );
             ignore = true;
             return this;
         }
@@ -79,6 +85,7 @@ public class MessageBinder
         if ( binder != null )
         {
             currentField = binding;
+            logger.trace( "Current param binder: {}", currentField );
             return binder;
         }
 

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MessageBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MessageBinder.java
@@ -85,7 +85,7 @@ public class MessageBinder
         if ( binder != null )
         {
             currentField = binding;
-            logger.trace( "Current param binder: {}", currentField );
+            logger.trace( "Current param binder: {} for field: {}", currentField, field );
             return binder;
         }
 

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MessageBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/MessageBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import org.apache.xbean.recipe.ObjectRecipe;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructMappingBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructMappingBinder.java
@@ -23,6 +23,8 @@ import org.commonjava.rwx.binding.spi.Binder;
 import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.spi.XmlRpcListener;
 import org.commonjava.rwx.vocab.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 
@@ -43,6 +45,8 @@ public class StructMappingBinder
                                 final XBRBindingContext context )
     {
         super( parent, type, mapping, context );
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Setting up struct mapping binder for: {}", type.getName() );
         recipe = XBRBindingContext.setupObjectRecipe( mapping );
     }
 
@@ -50,6 +54,10 @@ public class StructMappingBinder
     public XmlRpcListener structMember( final String key, final Object value, final ValueType type )
         throws XmlRpcException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Struct key: {} of type: {} with value: {} (class: {})", key, type, value,
+                      value == null ? "NULL" : value.getClass().getName() );
+
         if ( !ignore && currentField == null && value != null )
         {
             final FieldBinding binding = getMapping().getFieldBinding( key );

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructMappingBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructMappingBinder.java
@@ -20,6 +20,7 @@ import org.commonjava.rwx.binding.internal.xbr.XBRBindingContext;
 import org.commonjava.rwx.binding.mapping.FieldBinding;
 import org.commonjava.rwx.binding.mapping.StructMapping;
 import org.commonjava.rwx.binding.spi.Binder;
+import org.commonjava.rwx.binding.spi.value.ValueBinder;
 import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.spi.XmlRpcListener;
 import org.commonjava.rwx.vocab.ValueType;
@@ -74,6 +75,7 @@ public class StructMappingBinder
     protected Binder startStructMemberInternal( final String key )
         throws XmlRpcException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
         if ( ignore )
         {
             level++;
@@ -85,19 +87,22 @@ public class StructMappingBinder
             {
                 ignore = true;
                 level = 0;
+                logger.trace( "No field binding for: {}. Returning this binder.", key );
                 return this;
             }
 
             final Field field = getBindingContext().findField( binding, getType() );
 
-            final Binder binder = getBindingContext().newBinder( this, field );
+            Binder binder = getBindingContext().newBinder( this, field );
             if ( binder != null )
             {
                 currentField = binding;
+                logger.trace( "Current member binder: {} for field: {}", currentField, field );
                 return binder;
             }
         }
 
+        logger.trace( "Ignored field, or no binding available for: {}. Returning this binder.", key );
         return this;
     }
 

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructMappingBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructMappingBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructMappingBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructMappingBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import org.apache.xbean.recipe.ObjectRecipe;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructWrapperBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructWrapperBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr.helper;
 
 import static org.commonjava.rwx.binding.anno.AnnotationUtils.hasAnnotation;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructWrapperBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructWrapperBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructWrapperBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/internal/xbr/helper/StructWrapperBinder.java
@@ -23,6 +23,8 @@ import org.commonjava.rwx.binding.spi.Binder;
 import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.spi.XmlRpcListener;
 import org.commonjava.rwx.vocab.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StructWrapperBinder
     extends AbstractBinder
@@ -34,6 +36,8 @@ public class StructWrapperBinder
     public StructWrapperBinder( final Binder parent, final Class<?> valueType, final XBRBindingContext context )
     {
         super( parent, valueType, context );
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Setting up struct wrapper binder for: {}", valueType.getName() );
     }
 
     @Override
@@ -50,8 +54,10 @@ public class StructWrapperBinder
     public XmlRpcListener structMember( final String key, final Object value, final ValueType type )
         throws XmlRpcException
     {
-        if ( value == null )
+        if ( value != null )
         {
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.trace( "Setting value: {}" );
             this.value = value;
         }
 

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/AbstractMapping.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/AbstractMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/AbstractMapping.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/AbstractMapping.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.mapping;
 
 import java.io.IOException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/ArrayMapping.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/ArrayMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/ArrayMapping.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/ArrayMapping.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.mapping;
 
 public class ArrayMapping

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/FieldBinding.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/FieldBinding.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/FieldBinding.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/FieldBinding.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.mapping;
 
 import org.commonjava.rwx.binding.spi.value.ValueBinder;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/Mapping.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/Mapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/Mapping.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/Mapping.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.mapping;
 
 import java.io.Externalizable;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/MappingUtils.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/MappingUtils.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.mapping;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/MappingUtils.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/MappingUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/StructMapping.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/StructMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/mapping/StructMapping.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/mapping/StructMapping.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.mapping;
 
 public class StructMapping

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/Binder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/Binder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi;
 
 import org.commonjava.rwx.spi.XmlRpcListener;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/Binder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/Binder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/Bindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/Bindery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/Bindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/Bindery.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi;
 
 import org.commonjava.rwx.error.XmlRpcException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/BindingContext.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/BindingContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/BindingContext.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/BindingContext.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/Mapper.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/Mapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/Mapper.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/Mapper.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/CompositionBindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/CompositionBindery.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi.composed;
 
 import org.commonjava.rwx.binding.spi.Bindery;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/CompositionBindery.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/CompositionBindery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/ParsingBinderyDelegate.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/ParsingBinderyDelegate.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi.composed;
 
 import org.commonjava.rwx.binding.spi.Bindery;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/ParsingBinderyDelegate.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/ParsingBinderyDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/RenderingBinderyDelegate.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/RenderingBinderyDelegate.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi.composed;
 
 import org.commonjava.rwx.binding.spi.Bindery;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/RenderingBinderyDelegate.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/composed/RenderingBinderyDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/AbstractSimpleValueBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/AbstractSimpleValueBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/AbstractSimpleValueBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/AbstractSimpleValueBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi.value;
 
 import org.commonjava.rwx.binding.spi.Binder;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/AbstractValueBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/AbstractValueBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi.value;
 
 import org.commonjava.rwx.binding.internal.xbr.helper.AbstractBinder;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/AbstractValueBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/AbstractValueBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/ValueBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/ValueBinder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.spi.value;
 
 import org.commonjava.rwx.binding.mapping.Mapping;

--- a/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/ValueBinder.java
+++ b/bindings/src/main/java/org/commonjava/rwx/binding/spi/value/ValueBinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapperTest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapperTest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.reflect;
 
 import static org.junit.Assert.assertEquals;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapperTest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/internal/reflect/ReflectionMapperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinderTest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinderTest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/internal/reflect/ReflectionUnbinderTest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.reflect;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/internal/xbr/XBRCompositionBinderyTest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/internal/xbr/XBRCompositionBinderyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/internal/xbr/XBRCompositionBinderyTest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/internal/xbr/XBRCompositionBinderyTest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr;
 
 import static org.junit.Assert.assertEquals;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/internal/xbr/XBeanRenderingBinderyTest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/internal/xbr/XBeanRenderingBinderyTest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.internal.xbr;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/internal/xbr/XBeanRenderingBinderyTest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/internal/xbr/XBeanRenderingBinderyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/AnnotatedAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/AnnotatedAddress.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/AnnotatedAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/AnnotatedAddress.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataKey;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ArrayAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ArrayAddress.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.ArrayPart;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ArrayAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ArrayAddress.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse2.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse2.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse2.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse3.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse3.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse3.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import static org.commonjava.rwx.binding.testutil.recipe.RecipeEventUtils.endParameter;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse4.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse4.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse4.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse4.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse5.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse5.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse5.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponse5.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponseWithFinalFields.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponseWithFinalFields.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponseWithFinalFields.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponseWithFinalFields.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import static org.commonjava.rwx.binding.testutil.recipe.RecipeEventUtils.endParameter;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponseWithTwoAddresses.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponseWithTwoAddresses.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponseWithTwoAddresses.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ComposedPersonResponseWithTwoAddresses.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ConstructedPersonRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ConstructedPersonRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ConstructedPersonRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ConstructedPersonRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ConstructedPersonResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ConstructedPersonResponse.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ConstructedPersonResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/ConstructedPersonResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/EventAssertions.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/EventAssertions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InheritedPersonRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InheritedPersonRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InheritedPersonRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InheritedPersonRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import static org.commonjava.rwx.binding.testutil.recipe.RecipeEventUtils.parameter;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidAddressResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidAddressResponse.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidAddressResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidAddressResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidAddressResponse2.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidAddressResponse2.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidAddressResponse2.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidAddressResponse2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidFinalRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidFinalRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidFinalRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/InvalidFinalRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataIndexRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataIndexRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataIndexRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataIndexRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataKeyRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataKeyRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataKeyRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataKeyRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataKeyRequest2.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataKeyRequest2.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataKeyRequest2.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingDataKeyRequest2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingKeyAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingKeyAddress.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingKeyAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingKeyAddress.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataKey;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingKeyAddress2.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingKeyAddress2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingKeyAddress2.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/OverlappingKeyAddress2.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataKey;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/RecordedEvent.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/RecordedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/RecordingListener.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/RecordingListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleAddress.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.StructPart;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleAddress.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleAddressMapResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleAddressMapResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleAddressMapResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleAddressMapResponse.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import static org.commonjava.rwx.binding.testutil.recipe.RecipeEventUtils.endParameter;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleConverterRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleConverterRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import static org.commonjava.rwx.binding.testutil.recipe.RecipeEventUtils.endParameterWithConversion;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleConverterRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleConverterRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleFinalFieldAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleFinalFieldAddress.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleFinalFieldAddress.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleFinalFieldAddress.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.KeyRefs;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleListRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleListRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleListRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimpleListRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import static org.commonjava.rwx.binding.testutil.recipe.RecipeEventUtils.endParameter;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimplePersonRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimplePersonRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimplePersonRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimplePersonRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import static org.commonjava.rwx.binding.testutil.recipe.RecipeEventUtils.parameter;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimplePersonResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimplePersonResponse.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimplePersonResponse.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/SimplePersonResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithIgnored.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithIgnored.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithIgnored.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithIgnored.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataKey;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithInvalidFinalKey.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithInvalidFinalKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithInvalidFinalKey.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithInvalidFinalKey.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataKey;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithTransient.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithTransient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithTransient.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithTransient.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataKey;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithTransientKey.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithTransientKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithTransientKey.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/StructAddressWithTransientKey.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataKey;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TestDateConverter.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TestDateConverter.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.error.BindException;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TestDateConverter.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TestDateConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TestObject.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TestObject.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.mapping.Mapping;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TestObject.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TransientDataIndexRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TransientDataIndexRequest.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil;
 
 import org.commonjava.rwx.binding.anno.DataIndex;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TransientDataIndexRequest.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/TransientDataIndexRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/recipe/RecipeEventUtils.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/recipe/RecipeEventUtils.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.binding.testutil.recipe;
 
 import org.commonjava.rwx.estream.model.ArrayEvent;

--- a/bindings/src/test/java/org/commonjava/rwx/binding/testutil/recipe/RecipeEventUtils.java
+++ b/bindings/src/test/java/org/commonjava/rwx/binding/testutil/recipe/RecipeEventUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/error/CoercionException.java
+++ b/core/src/main/java/org/commonjava/rwx/error/CoercionException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/error/XmlRpcConfigurationException.java
+++ b/core/src/main/java/org/commonjava/rwx/error/XmlRpcConfigurationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/error/XmlRpcException.java
+++ b/core/src/main/java/org/commonjava/rwx/error/XmlRpcException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/error/XmlRpcFaultException.java
+++ b/core/src/main/java/org/commonjava/rwx/error/XmlRpcFaultException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/error/XmlRpcRenderException.java
+++ b/core/src/main/java/org/commonjava/rwx/error/XmlRpcRenderException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/EStreamUtils.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/EStreamUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/EventStreamGenerator.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/EventStreamGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/EventStreamParser.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/EventStreamParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/model/ArrayEvent.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/model/ArrayEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/model/Event.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/model/Event.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/model/ParameterEvent.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/model/ParameterEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/model/RequestEvent.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/model/RequestEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/model/ResponseEvent.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/model/ResponseEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/model/StructEvent.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/model/StructEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/estream/model/ValueEvent.java
+++ b/core/src/main/java/org/commonjava/rwx/estream/model/ValueEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/LoggingXmlRpcListener.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/LoggingXmlRpcListener.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.rwx.impl;
 
 import org.commonjava.rwx.error.XmlRpcException;

--- a/core/src/main/java/org/commonjava/rwx/impl/LoggingXmlRpcListener.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/LoggingXmlRpcListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/LoggingXmlRpcListener.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/LoggingXmlRpcListener.java
@@ -1,0 +1,183 @@
+package org.commonjava.rwx.impl;
+
+import org.commonjava.rwx.error.XmlRpcException;
+import org.commonjava.rwx.spi.XmlRpcListener;
+import org.commonjava.rwx.vocab.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by jdcasey on 1/8/16.
+ */
+public class LoggingXmlRpcListener
+    implements XmlRpcListener
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private XmlRpcListener delegate;
+
+    public LoggingXmlRpcListener( XmlRpcListener delegate )
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public XmlRpcListener value( Object value, ValueType type )
+            throws XmlRpcException
+    {
+        logger.info( "value: {} (type: {}, class: {})", value, type, value == null ? "NULL" : value.getClass().getName() );
+        return delegate.value( value, type );
+    }
+
+    @Override
+    public XmlRpcListener fault( int code, String message )
+            throws XmlRpcException
+    {
+        logger.info( "fault: {} (code: {})", message, code );
+        return delegate.fault( code, message );
+    }
+
+    @Override
+    public XmlRpcListener startRequest()
+            throws XmlRpcException
+    {
+        logger.info( "request started" );
+        return delegate.startRequest();
+    }
+
+    @Override
+    public XmlRpcListener requestMethod( String methodName )
+            throws XmlRpcException
+    {
+        logger.info( "request method: {}", methodName );
+        return delegate.requestMethod( methodName );
+    }
+
+    @Override
+    public XmlRpcListener endRequest()
+            throws XmlRpcException
+    {
+        logger.info( "request ended" );
+        return delegate.endRequest();
+    }
+
+    @Override
+    public XmlRpcListener startResponse()
+            throws XmlRpcException
+    {
+        logger.info( "response started" );
+        return delegate.startResponse();
+    }
+
+    @Override
+    public XmlRpcListener endResponse()
+            throws XmlRpcException
+    {
+        logger.info( "response ended" );
+        return delegate.endResponse();
+    }
+
+    @Override
+    public XmlRpcListener startParameter( int index )
+            throws XmlRpcException
+    {
+        logger.info( "parameter {} start", index );
+        return delegate.startParameter( index );
+    }
+
+    @Override
+    public XmlRpcListener endParameter()
+            throws XmlRpcException
+    {
+        logger.info( "parameter ended" );
+        return delegate.endParameter();
+    }
+
+    @Override
+    public XmlRpcListener parameter( int index, Object value, ValueType type )
+            throws XmlRpcException
+    {
+        logger.info( "parameter {} of type: {} is: {} (class: {})", index, type, value, value == null ? "NULL" : value.getClass().getName() );
+        return delegate.parameter( index, value, type );
+    }
+
+    @Override
+    public XmlRpcListener startArray()
+            throws XmlRpcException
+    {
+        logger.info( "array started" );
+        return delegate.startArray();
+    }
+
+    @Override
+    public XmlRpcListener startArrayElement( int index )
+            throws XmlRpcException
+    {
+        logger.info( "started array element {}", index );
+        return delegate.startArrayElement( index );
+    }
+
+    @Override
+    public XmlRpcListener endArrayElement()
+            throws XmlRpcException
+    {
+        logger.info( "ended array element" );
+        return delegate.endArrayElement();
+    }
+
+    @Override
+    public XmlRpcListener arrayElement( int index, Object value, ValueType type )
+            throws XmlRpcException
+    {
+        logger.info( "array element {} of type: {} is: {} (class: {})", index, type, value, value == null ? "NULL" : value.getClass().getName() );
+        return delegate.arrayElement( index, value, type );
+    }
+
+    @Override
+    public XmlRpcListener endArray()
+            throws XmlRpcException
+    {
+        logger.info( "ended array" );
+        return delegate.endArray();
+    }
+
+    @Override
+    public XmlRpcListener startStruct()
+            throws XmlRpcException
+    {
+        logger.info( "started struct" );
+        return delegate.startStruct();
+    }
+
+    @Override
+    public XmlRpcListener startStructMember( String key )
+            throws XmlRpcException
+    {
+        logger.info( "started struct member: {}", key );
+        return delegate.startStructMember( key );
+    }
+
+    @Override
+    public XmlRpcListener endStructMember()
+            throws XmlRpcException
+    {
+        logger.info( "ended struct member" );
+        return delegate.endStructMember();
+    }
+
+    @Override
+    public XmlRpcListener structMember( String key, Object value, ValueType type )
+            throws XmlRpcException
+    {
+        logger.info( "struct member {} of type: {} is: {} (class: {})", key, type, value, value == null ? "NULL" : value.getClass().getName() );
+        return delegate.structMember( key, value, type );
+    }
+
+    @Override
+    public XmlRpcListener endStruct()
+            throws XmlRpcException
+    {
+        logger.info( "ended struct" );
+        return delegate.endStruct();
+    }
+}

--- a/core/src/main/java/org/commonjava/rwx/impl/TrackingXmlRpcListener.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/TrackingXmlRpcListener.java
@@ -18,6 +18,8 @@ package org.commonjava.rwx.impl;
 import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.spi.XmlRpcListener;
 import org.commonjava.rwx.vocab.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
 
@@ -179,6 +181,10 @@ public class TrackingXmlRpcListener
         XmlRpcListener next = supplier.execute();
         last = current;
         current = next;
+
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Recording potential binder change.\nNew current binder: {}\nLast binder: {}\nFrom: {}", current,
+                      last, Thread.currentThread().getStackTrace()[1] );
 
         return next;
     }

--- a/core/src/main/java/org/commonjava/rwx/impl/TrackingXmlRpcListener.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/TrackingXmlRpcListener.java
@@ -19,11 +19,15 @@ import org.commonjava.rwx.error.XmlRpcException;
 import org.commonjava.rwx.spi.XmlRpcListener;
 import org.commonjava.rwx.vocab.ValueType;
 
+import java.util.function.Supplier;
+
 public class TrackingXmlRpcListener
     implements XmlRpcListener
 {
 
     private XmlRpcListener current;
+
+    private XmlRpcListener last;
 
     private final XmlRpcListener root;
 
@@ -31,6 +35,7 @@ public class TrackingXmlRpcListener
     {
         this.root = root;
         current = root;
+        last = null;
     }
 
     public XmlRpcListener getRoot()
@@ -43,124 +48,143 @@ public class TrackingXmlRpcListener
         return current;
     }
 
+    public XmlRpcListener getLast()
+    {
+        return last;
+    }
+
     public XmlRpcListener arrayElement( final int index, final Object value, final ValueType type )
         throws XmlRpcException
     {
-        return current = current.arrayElement( index, value, type );
+        return record(()->current.arrayElement( index, value, type ));
     }
 
     public XmlRpcListener endArray()
         throws XmlRpcException
     {
-        return current = current.endArray();
+        return record(()->current.endArray());
     }
 
     public XmlRpcListener endArrayElement()
         throws XmlRpcException
     {
-        return current = current.endArrayElement();
+        return record(()->current.endArrayElement());
     }
 
     public XmlRpcListener endParameter()
         throws XmlRpcException
     {
-        return current = current.endParameter();
+        return record(()->current.endParameter());
     }
 
     public XmlRpcListener endRequest()
         throws XmlRpcException
     {
-        return current = current.endRequest();
+        return record(()->current.endRequest());
     }
 
     public XmlRpcListener endResponse()
         throws XmlRpcException
     {
-        return current = current.endResponse();
+        return record(()->current.endResponse());
     }
 
     public XmlRpcListener endStruct()
         throws XmlRpcException
     {
-        return current = current.endStruct();
+        return record(()->current.endStruct());
     }
 
     public XmlRpcListener endStructMember()
         throws XmlRpcException
     {
-        return current = current.endStructMember();
+        return record(()->current.endStructMember());
     }
 
     public XmlRpcListener fault( final int code, final String message )
         throws XmlRpcException
     {
-        return current = current.fault( code, message );
+        return record(()->current.fault( code, message ));
     }
 
     public XmlRpcListener parameter( final int index, final Object value, final ValueType type )
         throws XmlRpcException
     {
-        return current = current.parameter( index, value, type );
+        return record(()->current.parameter( index, value, type ));
     }
 
     public XmlRpcListener requestMethod( final String methodName )
         throws XmlRpcException
     {
-        return current = current.requestMethod( methodName );
+        return record(()->current.requestMethod( methodName ));
     }
 
     public XmlRpcListener startArray()
         throws XmlRpcException
     {
-        return current = current.startArray();
+        return record(()->current.startArray());
     }
 
     public XmlRpcListener startArrayElement( final int index )
         throws XmlRpcException
     {
-        return current = current.startArrayElement( index );
+        return record(()->current.startArrayElement( index ));
     }
 
     public XmlRpcListener startParameter( final int index )
         throws XmlRpcException
     {
-        return current = current.startParameter( index );
+        return record(()->current.startParameter( index ));
     }
 
     public XmlRpcListener startRequest()
         throws XmlRpcException
     {
-        return current = current.startRequest();
+        return record(()->current.startRequest());
     }
 
     public XmlRpcListener startResponse()
         throws XmlRpcException
     {
-        return current = current.startResponse();
+        return record(()->current.startResponse());
     }
 
     public XmlRpcListener startStruct()
         throws XmlRpcException
     {
-        return current = current.startStruct();
+        return record(()->current.startStruct());
     }
 
     public XmlRpcListener startStructMember( final String key )
         throws XmlRpcException
     {
-        return current = current.startStructMember( key );
+        return record(()->current.startStructMember( key ));
     }
 
     public XmlRpcListener structMember( final String key, final Object value, final ValueType type )
         throws XmlRpcException
     {
-        return current = current.structMember( key, value, type );
+        return record(()->current.structMember( key, value, type ));
     }
 
     public XmlRpcListener value( final Object value, final ValueType type )
         throws XmlRpcException
     {
-        return current = current.value( value, type );
+        return record(()->current.value( value, type ));
     }
 
+    private XmlRpcListener record( RecordingOp<XmlRpcListener> supplier )
+            throws XmlRpcException
+    {
+        XmlRpcListener next = supplier.execute();
+        last = current;
+        current = next;
+
+        return next;
+    }
+
+    public interface RecordingOp<T>
+    {
+        XmlRpcListener execute() throws XmlRpcException;
+    }
 }

--- a/core/src/main/java/org/commonjava/rwx/impl/TrackingXmlRpcListener.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/TrackingXmlRpcListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/estream/EventStreamGeneratorImpl.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/estream/EventStreamGeneratorImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/estream/EventStreamGeneratorImpl.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/estream/EventStreamGeneratorImpl.java
@@ -26,6 +26,8 @@ import org.commonjava.rwx.estream.model.StructEvent;
 import org.commonjava.rwx.estream.model.ValueEvent;
 import org.commonjava.rwx.impl.TrackingXmlRpcListener;
 import org.commonjava.rwx.spi.XmlRpcListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -90,6 +92,9 @@ public class EventStreamGeneratorImpl
         {
             for ( final Event<?> e : events )
             {
+                Logger logger = LoggerFactory.getLogger( getClass() );
+                logger.trace( "Firing: {} into listener: {}", e, listener );
+
                 switch ( e.getEventType() )
                 {
                     case VALUE:

--- a/core/src/main/java/org/commonjava/rwx/impl/estream/EventStreamParserImpl.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/estream/EventStreamParserImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/jdom/JDomRenderer.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/jdom/JDomRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/stax/StaxParser.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/stax/StaxParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/stax/helper/ArrayHelper.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/stax/helper/ArrayHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/stax/helper/FaultHelper.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/stax/helper/FaultHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/stax/helper/ParamHelper.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/stax/helper/ParamHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/stax/helper/RequestHelper.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/stax/helper/RequestHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/stax/helper/ResponseHelper.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/stax/helper/ResponseHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/stax/helper/StructHelper.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/stax/helper/StructHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/impl/stax/helper/ValueHelper.java
+++ b/core/src/main/java/org/commonjava/rwx/impl/stax/helper/ValueHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/spi/AbstractXmlRpcListener.java
+++ b/core/src/main/java/org/commonjava/rwx/spi/AbstractXmlRpcListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/spi/FaultAwareWrapper.java
+++ b/core/src/main/java/org/commonjava/rwx/spi/FaultAwareWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/spi/XmlRpcGenerator.java
+++ b/core/src/main/java/org/commonjava/rwx/spi/XmlRpcGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/spi/XmlRpcListener.java
+++ b/core/src/main/java/org/commonjava/rwx/spi/XmlRpcListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/spi/XmlRpcParser.java
+++ b/core/src/main/java/org/commonjava/rwx/spi/XmlRpcParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/util/LambdaHolder.java
+++ b/core/src/main/java/org/commonjava/rwx/util/LambdaHolder.java
@@ -1,0 +1,24 @@
+package org.commonjava.rwx.util;
+
+/**
+ * Created by jdcasey on 1/14/16.
+ */
+public class LambdaHolder<T>
+{
+    private T value;
+
+    public T get()
+    {
+        return value;
+    }
+
+    public void set( T value )
+    {
+        this.value = value;
+    }
+
+    public boolean has()
+    {
+        return value != null;
+    }
+}

--- a/core/src/main/java/org/commonjava/rwx/util/LambdaHolder.java
+++ b/core/src/main/java/org/commonjava/rwx/util/LambdaHolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/util/LambdaHolder.java
+++ b/core/src/main/java/org/commonjava/rwx/util/LambdaHolder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.rwx.util;
 
 /**

--- a/core/src/main/java/org/commonjava/rwx/util/ValueCoercion.java
+++ b/core/src/main/java/org/commonjava/rwx/util/ValueCoercion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/vocab/EventType.java
+++ b/core/src/main/java/org/commonjava/rwx/vocab/EventType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/vocab/ValueType.java
+++ b/core/src/main/java/org/commonjava/rwx/vocab/ValueType.java
@@ -85,7 +85,8 @@ public enum ValueType
         {
             try
             {
-                return value == null ? null : Integer.parseInt( value );
+                String val = value == null ? null : value.trim();
+                return val == null || val.length() < 1 ? null : Integer.parseInt( val );
             }
             catch ( final NumberFormatException e )
             {
@@ -106,7 +107,7 @@ public enum ValueType
             }
             else
             {
-                final String s = super.toString( value );
+                final String s = super.toString( value ).trim();
                 if ( "1".equals( s ) || "0".equals( s ) )
                 {
                     return s;
@@ -127,7 +128,8 @@ public enum ValueType
             }
             else
             {
-                return "1".equals( value ) || Boolean.valueOf( value );
+                String val = value.trim();
+                return "1".equals( val ) || Boolean.valueOf( val );
             }
         }
     }, Boolean.class, "boolean" ),
@@ -137,7 +139,7 @@ public enum ValueType
         @Override
         public Object fromString( final String value )
         {
-            return value;
+            return value == null ? null : value.trim();
         }
     }, String.class, "string" ),
 
@@ -149,7 +151,8 @@ public enum ValueType
         {
             try
             {
-                return value == null ? null : Double.parseDouble( value );
+                String val = value == null ? null : value.trim();
+                return val == null || val.length() < 1 ? null : Double.parseDouble( val );
             }
             catch ( final NumberFormatException e )
             {
@@ -174,7 +177,8 @@ public enum ValueType
         {
             try
             {
-                return value == null ? null : new SimpleDateFormat( FORMAT ).parse( value );
+                String val = value == null ? null : value.trim();
+                return val == null ? null : new SimpleDateFormat( FORMAT ).parse( value );
             }
             catch ( final ParseException e )
             {
@@ -209,7 +213,7 @@ public enum ValueType
                 return null;
             }
 
-            final byte[] result = Base64.decodeBase64( value );
+            final byte[] result = Base64.decodeBase64( value.trim() );
             if ( result.length < 1 && value.length() > 0 && !value.equals( "==" ) && !value.equals( "=" ) )
             {
                 throw new CoercionException( "Invalid Base64 input: " + value );

--- a/core/src/main/java/org/commonjava/rwx/vocab/ValueType.java
+++ b/core/src/main/java/org/commonjava/rwx/vocab/ValueType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/rwx/vocab/XmlRpcConstants.java
+++ b/core/src/main/java/org/commonjava/rwx/vocab/XmlRpcConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/EventStreamGeneratorTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/EventStreamGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/EventStreamParserTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/EventStreamParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/model/AbstractEventTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/model/AbstractEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/model/ArrayEventTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/model/ArrayEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/model/ParameterEventTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/model/ParameterEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/model/RequestEventTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/model/RequestEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/model/ResponseEventTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/model/ResponseEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/model/StructEventTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/model/StructEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/model/ValueEventTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/model/ValueEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/EventAssertions.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/EventAssertions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/ExtList.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/ExtList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/ExtListOfArrays.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/ExtListOfArrays.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/ExtMap.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/ExtMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/RecordedEvent.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/RecordedEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/RecordingListener.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/estream/testutil/RecordingListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/jdom/JDomRendererTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/jdom/JDomRendererTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/AbstractStaxTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/AbstractStaxTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/StaxParserTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/StaxParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/helper/AbstractStaxHelperTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/helper/AbstractStaxHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/helper/ArrayHelperTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/helper/ArrayHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/helper/FaultHelperTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/helper/FaultHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/helper/ParamHelperTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/helper/ParamHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/helper/RequestHelperTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/helper/RequestHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/helper/ResponseHelperTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/helper/ResponseHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/helper/StructHelperTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/helper/StructHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/impl/stax/helper/ValueHelperTest.java
+++ b/core/src/test/java/org/commonjava/rwx/impl/stax/helper/ValueHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/testutil/ValueUtils.java
+++ b/core/src/test/java/org/commonjava/rwx/testutil/ValueUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/ARRAY_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/ARRAY_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/AbstractValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/AbstractValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/BASE64_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/BASE64_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/BOOLEAN_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/BOOLEAN_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/DATETIME_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/DATETIME_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/DOUBLE_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/DOUBLE_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/INT_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/INT_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/NIL_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/NIL_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/STRING_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/STRING_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/rwx/vocab/STRUCT_ValueTypeTest.java
+++ b/core/src/test/java/org/commonjava/rwx/vocab/STRUCT_ValueTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/experimental/pom.xml
+++ b/experimental/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -1,18 +1,19 @@
 <!--
-  Copyright (c) 2010 Red Hat, Inc.
-  
-  This program is licensed to you under Version 3 only of the GNU
-  General Public License as published by the Free Software 
-  Foundation. This program is distributed in the hope that it will be 
-  useful, but WITHOUT ANY WARRANTY; without even the implied 
-  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
-  PURPOSE.
-  
-  See the GNU General Public License Version 3 for more details.
-  You should have received a copy of the GNU General Public License 
-  Version 3 along with this program. 
-  
-  If not, see http://www.gnu.org/licenses/.
+
+    Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/RequestModifier.java
+++ b/http/src/main/java/org/commonjava/rwx/http/RequestModifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/RequestModifier.java
+++ b/http/src/main/java/org/commonjava/rwx/http/RequestModifier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.rwx.http;
 
 import org.apache.http.client.methods.HttpPost;

--- a/http/src/main/java/org/commonjava/rwx/http/SyncEStreamClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/SyncEStreamClient.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.http;
 
 import org.commonjava.rwx.error.XmlRpcException;

--- a/http/src/main/java/org/commonjava/rwx/http/SyncEStreamClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/SyncEStreamClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/SyncObjectClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/SyncObjectClient.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.http;
 
 import org.commonjava.rwx.error.XmlRpcException;

--- a/http/src/main/java/org/commonjava/rwx/http/SyncObjectClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/SyncObjectClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/UrlBuilder.java
+++ b/http/src/main/java/org/commonjava/rwx/http/UrlBuilder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.rwx.http;
 
 import java.net.MalformedURLException;

--- a/http/src/main/java/org/commonjava/rwx/http/UrlBuilder.java
+++ b/http/src/main/java/org/commonjava/rwx/http/UrlBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/error/XmlRpcTransportException.java
+++ b/http/src/main/java/org/commonjava/rwx/http/error/XmlRpcTransportException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/error/XmlRpcTransportException.java
+++ b/http/src/main/java/org/commonjava/rwx/http/error/XmlRpcTransportException.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.http.error;
 
 import org.commonjava.rwx.error.XmlRpcException;

--- a/http/src/main/java/org/commonjava/rwx/http/httpclient4/EStreamResponseHandler.java
+++ b/http/src/main/java/org/commonjava/rwx/http/httpclient4/EStreamResponseHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/httpclient4/EStreamResponseHandler.java
+++ b/http/src/main/java/org/commonjava/rwx/http/httpclient4/EStreamResponseHandler.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.http.httpclient4;
 
 import org.apache.commons.io.IOUtils;

--- a/http/src/main/java/org/commonjava/rwx/http/httpclient4/HC4SyncEStreamClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/httpclient4/HC4SyncEStreamClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/httpclient4/HC4SyncEStreamClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/httpclient4/HC4SyncEStreamClient.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.http.httpclient4;
 
 import org.apache.commons.io.IOUtils;

--- a/http/src/main/java/org/commonjava/rwx/http/httpclient4/HC4SyncObjectClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/httpclient4/HC4SyncObjectClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/httpclient4/HC4SyncObjectClient.java
+++ b/http/src/main/java/org/commonjava/rwx/http/httpclient4/HC4SyncObjectClient.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.http.httpclient4;
 
 import org.apache.commons.io.IOUtils;

--- a/http/src/main/java/org/commonjava/rwx/http/httpclient4/ObjectResponseHandler.java
+++ b/http/src/main/java/org/commonjava/rwx/http/httpclient4/ObjectResponseHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/httpclient4/ObjectResponseHandler.java
+++ b/http/src/main/java/org/commonjava/rwx/http/httpclient4/ObjectResponseHandler.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.http.httpclient4;
 
 import org.apache.commons.io.IOUtils;

--- a/http/src/main/java/org/commonjava/rwx/http/util/FinalHolder.java
+++ b/http/src/main/java/org/commonjava/rwx/http/util/FinalHolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/src/main/java/org/commonjava/rwx/http/util/FinalHolder.java
+++ b/http/src/main/java/org/commonjava/rwx/http/util/FinalHolder.java
@@ -1,20 +1,18 @@
-/*
- *  Copyright (c) 2010 Red Hat, Inc.
- *  
- *  This program is licensed to you under Version 3 only of the GNU
- *  General Public License as published by the Free Software 
- *  Foundation. This program is distributed in the hope that it will be 
- *  useful, but WITHOUT ANY WARRANTY; without even the implied 
- *  warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
- *  PURPOSE.
- *  
- *  See the GNU General Public License Version 3 for more details.
- *  You should have received a copy of the GNU General Public License 
- *  Version 3 along with this program. 
- *  
- *  If not, see http://www.gnu.org/licenses/.
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.commonjava.rwx.http.util;
 
 public final class FinalHolder<T>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@
   <version>0.2.2-SNAPSHOT</version>
   
   <packaging>pom</packaging>
+  <inceptionYear>2010</inceptionYear>
   
   <name>RWX XML-RPC APIs for Java</name>
 


### PR DESCRIPTION
- new annotation: SkipNull (don't output <nil/> if value is null)
- support Converter at type level for custom data types that need to be serialized/deserialized consistently
- if field is collection and has @Converter but no @Contains, use the converter on the whole value (not a collection/map binder)
