### PR TITLE
Add proper hashcode/equals for Nil

### DIFF
--- a/rwx/src/main/java/org/commonjava/rwx/vocab/Nil.java
+++ b/rwx/src/main/java/org/commonjava/rwx/vocab/Nil.java
@@ -7,5 +7,19 @@ public class Nil
 {
     public static Nil NIL_VALUE = new Nil();
 
-    private Nil() {}
+    private Nil()
+    {
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return 31;
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        return ( obj instanceof Nil );
+    }
 }


### PR DESCRIPTION
This is not directly related to any bug. Adding this for users who want to compare two Nil objects after ser/deser, etc. 