### PR TITLE
Make Nil externalizable

### DIFF
--- a/rwx/src/main/java/org/commonjava/rwx/vocab/Nil.java
+++ b/rwx/src/main/java/org/commonjava/rwx/vocab/Nil.java
@@ -15,16 +15,28 @@
  */
 package org.commonjava.rwx.vocab;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+
 /**
  * Created by ruhan on 12/14/17.
  */
 public class Nil
+    implements Serializable
 {
-    public static Nil NIL_VALUE = new Nil();
+    private static final long serialVersionUID = 5398616344106741077L;
 
-    private Nil()
-    {
-    }
+    private static final int VERSION = 1;
+
+    public static final Nil NIL_VALUE = new Nil();
+
+   private Nil()
+   {
+
+   }
 
     @Override
     public int hashCode()
@@ -36,5 +48,41 @@ public class Nil
     public boolean equals( Object obj )
     {
         return ( obj instanceof Nil );
+    }
+
+    private Object writeReplace()
+    {
+        return new Proxy();
+    }
+
+    private static class Proxy
+        implements Externalizable
+    {
+        public Proxy()
+        {
+
+        }
+
+        @Override
+        public void writeExternal( ObjectOutput out )
+                throws IOException {
+            out.writeInt( VERSION );
+        }
+
+        @Override
+        public void readExternal( ObjectInput in )
+                throws IOException {
+            int version = in.readInt();
+
+            if ( version != 1 )
+            {
+                throw new IOException( "Invalid version: " + version );
+            }
+        }
+
+        private Object readResolve()
+        {
+            return NIL_VALUE;
+        }
     }
 }

--- a/rwx/src/test/java/org/commonjava/rwx/vocab/NilTest.java
+++ b/rwx/src/test/java/org/commonjava/rwx/vocab/NilTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2010 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.rwx.vocab;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class NilTest
+{
+    @Test
+    public void serializationTest() throws IOException, ClassNotFoundException
+    {
+        Object result = null;
+
+        try ( ByteArrayOutputStream bout = new ByteArrayOutputStream(); ObjectOutputStream out = new ObjectOutputStream( bout ) )
+        {
+            out.writeObject( Nil.NIL_VALUE );
+
+            out.close();
+
+            try ( ByteArrayInputStream bin = new ByteArrayInputStream( bout.toByteArray() ); ObjectInputStream in = new ObjectInputStream( bin ) )
+            {
+                result = in.readObject();
+            }
+        }
+
+        assertEquals( Nil.NIL_VALUE, result );
+
+        assertEquals( result, Nil.NIL_VALUE );
+
+        assertTrue( Nil.NIL_VALUE == result );
+    }
+}


### PR DESCRIPTION
Implement Serializable for Nil. Additionally, since Nil is a singleton,
create an inner Proxy class which implements Externalizable whereby
serializing Nil writes Nil.Proxy to the stream instead and reading
Nil.Proxy from the stream returns the Nil singleton instance.